### PR TITLE
Print descriptive error message on startup when TinyGo flags are not set

### DIFF
--- a/finalizer.go
+++ b/finalizer.go
@@ -1,7 +1,7 @@
 // Copyright wasilibs authors
 // SPDX-License-Identifier: MIT
 
-//go:build nottinygc_finalizer
+//go:build gc.custom && nottinygc_finalizer
 
 package nottinygc
 

--- a/gc.go
+++ b/gc.go
@@ -1,6 +1,8 @@
 // Copyright wasilibs authors
 // SPDX-License-Identifier: MIT
 
+//go:build gc.custom
+
 package nottinygc
 
 import (

--- a/gc_notcustom.go
+++ b/gc_notcustom.go
@@ -1,0 +1,10 @@
+// Copyright wasilibs authors
+// SPDX-License-Identifier: MIT
+
+//go:build !gc.custom
+
+package nottinygc
+
+func init() {
+	panic("nottinygc requires passing -gc=custom and -tags=custommalloc to TinyGo when compiling.\nhttps://github.com/wasilibs/nottinygc#usage")
+}


### PR DESCRIPTION
As opposed to a build failure mentioning duplicate symbols and nothing else.