### PR TITLE
Rename build tag to envoy instead of proxywasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ This library relies on WASI to implement certain functionality, for which Envoy'
 is incomplete, and in addition, it's ABI, proxy-wasm has design issues that prevent working with
 defaults appropriate for normal TinyGo applications. As this project is commonly used with Envoy,
 we provide a build tag, to work around these issues. If building an Envoy plugin, add
-`-tags=nottinygc_proxywasm` (or combine it with additional tags) to your TinyGo build flags. This
+`-tags=nottinygc_envoy` (or combine it with additional tags) to your TinyGo build flags. This
 will disable export of `malloc`/`free`/ and define a no-op `sched_yield` function.
 
 Other hosts that implement WASI fully, such as [wazero][3] and ABIs with correct memory semantics,
-such as [http-wasm][5], will not have any issue.
+such as [http-wasm][5], will not have any issue. Implementations of proxy-wasm other than Envoy
+may also work fine without the build tag.
 
 ## Performance
 

--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -42,8 +42,8 @@ func TestExportsMalloc(t *testing.T) {
 	}
 }
 
-func TestProxyWasmDoesNotExportMalloc(t *testing.T) {
-	wasm, err := os.ReadFile(filepath.Join("..", "build", "bench_proxywasm.wasm"))
+func TestEnvoyDoesNotExportMalloc(t *testing.T) {
+	wasm, err := os.ReadFile(filepath.Join("..", "build", "bench_envoy.wasm"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/init_default.go
+++ b/init_default.go
@@ -1,7 +1,7 @@
 // Copyright wasilibs authors
 // SPDX-License-Identifier: MIT
 
-//go:build tinygo && !nottinygc_proxywasm
+//go:build tinygo && !nottinygc_envoy
 
 package nottinygc
 

--- a/init_proxywasm.go
+++ b/init_proxywasm.go
@@ -1,7 +1,7 @@
 // Copyright wasilibs authors
 // SPDX-License-Identifier: MIT
 
-//go:build tinygo && nottinygc_proxywasm
+//go:build tinygo && nottinygc_envoy
 
 package nottinygc
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -138,7 +138,7 @@ func buildBenchExecutable() error {
 		return err
 	}
 
-	if err := sh.RunV("tinygo", "build", "-gc=custom", "-tags='custommalloc nottinygc_proxywasm'", "-scheduler=none", "-target=wasi", "-o", "build/bench_proxywasm.wasm", "./bench"); err != nil {
+	if err := sh.RunV("tinygo", "build", "-gc=custom", "-tags='custommalloc nottinygc_envoy'", "-scheduler=none", "-target=wasi", "-o", "build/bench_envoy.wasm", "./bench"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The issues are specific to Envoy's implementation, not necessarily for all proxywasm implementations