### PR TITLE
Initialize descriptor cache in initHeap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,5 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
 
       - run: go run mage.go test
+
+      - run: go run mage.go e2eGzip

--- a/e2e/gzip/go.mod
+++ b/e2e/gzip/go.mod
@@ -1,0 +1,7 @@
+module gzip-test
+
+go 1.20
+
+require github.com/wasilibs/nottinygc v0.7.0
+
+require github.com/magefile/mage v1.14.0 // indirect

--- a/e2e/gzip/go.sum
+++ b/e2e/gzip/go.sum
@@ -1,0 +1,4 @@
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/wasilibs/nottinygc v0.7.0 h1:x8PiLXMHiSx8v4MgyL8T4LEp0FqrPtqZDsveI9xiY3M=
+github.com/wasilibs/nottinygc v0.7.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=

--- a/e2e/gzip/main.go
+++ b/e2e/gzip/main.go
@@ -1,0 +1,16 @@
+// Copyright wasilibs authors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+
+	_ "github.com/wasilibs/nottinygc"
+)
+
+func main() {
+	r := bytes.NewReader([]byte{})
+	gzip.NewReader(r)
+}

--- a/gc.go
+++ b/gc.go
@@ -46,7 +46,7 @@ const (
 	gcDsBitmap = uintptr(1)
 )
 
-var descriptorCache = newIntMap()
+var descriptorCache intMap
 
 //export onCollectionEvent
 func onCollectionEvent(eventType uint32) {
@@ -60,6 +60,8 @@ func onCollectionEvent(eventType uint32) {
 //
 //go:linkname initHeap runtime.initHeap
 func initHeap() {
+	descriptorCache = newIntMap()
+
 	C.GC_set_on_collection_event(C.onCollectionEvent)
 	// We avoid overhead in calling GC_make_descriptor on every allocation by implementing
 	// the bitmap computation in Go, but we need to call it at least once to initialize

--- a/go.work
+++ b/go.work
@@ -6,5 +6,6 @@ use (
 	.
 	./bench
 	./e2e/envoy-dispatch-call
+	./e2e/gzip
 	./e2e/higress-gc-test
 )

--- a/intmap_test.go
+++ b/intmap_test.go
@@ -6,7 +6,7 @@ package nottinygc
 import "testing"
 
 func TestIntMapBasic(t *testing.T) {
-	m := newIntMap()
+	var m intMap
 	_, ok := m.get(5)
 	if ok {
 		t.Fatal("expected not ok in empty map")
@@ -24,7 +24,7 @@ func TestIntMapBasic(t *testing.T) {
 
 func TestIntMapNoResize(t *testing.T) {
 	top := int(0.75 * 512)
-	m := newIntMap()
+	var m intMap
 	for i := 0; i < top; i++ {
 		m.put(uintptr(i), uintptr(i))
 	}
@@ -50,7 +50,7 @@ func TestIntMapNoResize(t *testing.T) {
 
 func TestIntMapResize(t *testing.T) {
 	top := 512
-	m := newIntMap()
+	var m intMap
 	for i := 0; i < top; i++ {
 		m.put(uintptr(i), uintptr(i))
 	}

--- a/intmap_test.go
+++ b/intmap_test.go
@@ -6,7 +6,7 @@ package nottinygc
 import "testing"
 
 func TestIntMapBasic(t *testing.T) {
-	var m intMap
+	m := newIntMap()
 	_, ok := m.get(5)
 	if ok {
 		t.Fatal("expected not ok in empty map")
@@ -24,7 +24,7 @@ func TestIntMapBasic(t *testing.T) {
 
 func TestIntMapNoResize(t *testing.T) {
 	top := int(0.75 * 512)
-	var m intMap
+	m := newIntMap()
 	for i := 0; i < top; i++ {
 		m.put(uintptr(i), uintptr(i))
 	}
@@ -50,7 +50,7 @@ func TestIntMapNoResize(t *testing.T) {
 
 func TestIntMapResize(t *testing.T) {
 	top := 512
-	var m intMap
+	m := newIntMap()
 	for i := 0; i < top; i++ {
 		m.put(uintptr(i), uintptr(i))
 	}

--- a/magefiles/e2e.go
+++ b/magefiles/e2e.go
@@ -159,6 +159,23 @@ func E2eHigressGCTest() error {
 	return nil
 }
 
+func E2eGzip() error {
+	if err := os.MkdirAll(filepath.Join("e2e", "gzip", "build"), 0o755); err != nil {
+		return err
+	}
+
+	if err := sh.RunV("tinygo", "build", "-target=wasi", "-gc=custom", "-tags='custommalloc'", "-scheduler=none",
+		"-o", filepath.Join("e2e", "gzip", "build", "main.wasm"), "./e2e/gzip"); err != nil {
+		return err
+	}
+
+	if err := sh.RunV("wasmtime", filepath.Join("e2e", "gzip", "build", "main.wasm")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type counterStat struct {
 	Name  string `json:"name"`
 	Value int    `json:"value"`


### PR DESCRIPTION
`init` is not always called in correct order.

Fixes #41